### PR TITLE
Improve prediction-market backtest slippage and Polymarket fee modeling

### DIFF
--- a/examples/backtest/prediction_markets/README.md
+++ b/examples/backtest/prediction_markets/README.md
@@ -68,6 +68,44 @@ Default chart readability settings for this comparison set:
 - Polymarket defaults use a lower-activity public market so the public trades API
   stays within its historical offset ceiling while still producing non-flat charts.
 
+## Execution Modeling
+
+Prediction-market backtests here replay venue data into Nautilus Trader and then
+apply execution assumptions inside the backtest engine. For the current shared
+Kalshi and Polymarket runners, the main performance impacts beyond the raw API
+data are:
+
+- venue fees
+- slippage for taker-style orders
+
+### Fees
+
+- Kalshi uses the nonlinear expected-earnings fee model in
+  `nautilus_trader.adapters.kalshi.fee_model.KalshiProportionalFeeModel`.
+- Polymarket uses `nautilus_trader.adapters.polymarket.fee_model.PolymarketFeeModel`.
+- Polymarket loader instruments are enriched from the CLOB `fee-rate` endpoint
+  when the market payload itself reports zero fees, so fee-enabled markets can
+  backtest with the live fee source used by order creation.
+- If the venue reports zero fees for a market, the backtest also applies zero fees.
+
+### Slippage
+
+- Shared prediction-market backtests now default to
+  `PredictionMarketTakerFillModel`.
+- This applies a deterministic one-tick adverse fill for non-limit orders.
+- Polymarket uses the instrument tick size from market metadata.
+- Kalshi uses one cent as the effective order tick for taker slippage.
+- Limit orders keep the default matching behavior and do not get the forced
+  one-tick adverse move.
+
+### Limits
+
+- This is a conservative taker-execution proxy, not full microstructure replay.
+- Historical prediction-market backtests here do not replay full order-book
+  depth, queue position, or partial sweep behavior.
+- If a strategy depends on harvesting very small price changes with IOC or
+  market-style orders, one-tick slippage can dominate performance.
+
 ## Conventions
 
 - Keep venue-specific data access in adapter research modules.

--- a/nautilus_trader/adapters/polymarket/loaders.py
+++ b/nautilus_trader/adapters/polymarket/loaders.py
@@ -18,6 +18,8 @@ Provides data loaders for historical Polymarket data from various APIs.
 
 from __future__ import annotations
 
+from decimal import Decimal
+from decimal import InvalidOperation
 from typing import Any
 
 import msgspec
@@ -61,6 +63,7 @@ class PolymarketDataLoader:
     """
 
     _TRADES_PAGE_LIMIT = 1_000
+    _FEE_RATE_URL = "https://clob.polymarket.com/fee-rate"
 
     def __init__(
         self,
@@ -132,6 +135,64 @@ class PolymarketDataLoader:
             )
 
         return msgspec.json.decode(response.body)
+
+    @staticmethod
+    def _coerce_fee_rate_bps(value: Any) -> Decimal | None:
+        if value in (None, ""):
+            return None
+
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, TypeError, ValueError):
+            return None
+
+    @classmethod
+    async def _fetch_market_fee_rate_bps(
+        cls,
+        token_id: str,
+        http_client: nautilus_pyo3.HttpClient,
+    ) -> Decimal | None:
+        PyCondition.valid_string(token_id, "token_id")
+
+        response = await http_client.get(
+            url=cls._FEE_RATE_URL,
+            params={"token_id": token_id},
+        )
+        if response.status != 200:
+            return None
+
+        payload = msgspec.json.decode(response.body)
+        if not isinstance(payload, dict):
+            return None
+
+        fee_rate_bps = cls._coerce_fee_rate_bps(payload.get("fee_rate_bps"))
+        if fee_rate_bps is not None:
+            return fee_rate_bps
+
+        return cls._coerce_fee_rate_bps(payload.get("base_fee"))
+
+    @classmethod
+    async def _enrich_market_details_with_fee_rate(
+        cls,
+        market_details: dict[str, Any],
+        token_id: str,
+        http_client: nautilus_pyo3.HttpClient,
+    ) -> dict[str, Any]:
+        existing_maker_fee = cls._coerce_fee_rate_bps(market_details.get("maker_base_fee"))
+        existing_taker_fee = cls._coerce_fee_rate_bps(market_details.get("taker_base_fee"))
+        if (existing_maker_fee is not None and existing_maker_fee > 0) or (
+            existing_taker_fee is not None and existing_taker_fee > 0
+        ):
+            return market_details
+
+        fee_rate_bps = await cls._fetch_market_fee_rate_bps(token_id, http_client)
+        if fee_rate_bps is None:
+            return market_details
+
+        enriched = dict(market_details)
+        enriched["maker_base_fee"] = str(fee_rate_bps)
+        enriched["taker_base_fee"] = str(fee_rate_bps)
+        return enriched
 
     @staticmethod
     async def _fetch_event_by_slug(
@@ -226,6 +287,11 @@ class PolymarketDataLoader:
         )
         if is_50_50_outcome:
             market_details["is_50_50_outcome"] = True
+        market_details = await cls._enrich_market_details_with_fee_rate(
+            market_details,
+            token_id,
+            client,
+        )
 
         instrument = parse_polymarket_instrument(
             market_info=market_details,
@@ -302,6 +368,11 @@ class PolymarketDataLoader:
             token = tokens[token_index]
             token_id = token["token_id"]
             outcome = token["outcome"]
+            market_details = await cls._enrich_market_details_with_fee_rate(
+                market_details,
+                token_id,
+                client,
+            )
 
             instrument = parse_polymarket_instrument(
                 market_info=market_details,

--- a/nautilus_trader/adapters/prediction_market/__init__.py
+++ b/nautilus_trader/adapters/prediction_market/__init__.py
@@ -15,3 +15,7 @@
 """
 Shared prediction-market adapter helpers.
 """
+
+from nautilus_trader.adapters.prediction_market.fill_model import PredictionMarketTakerFillModel
+
+__all__ = ["PredictionMarketTakerFillModel"]

--- a/nautilus_trader/adapters/prediction_market/fill_model.py
+++ b/nautilus_trader/adapters/prediction_market/fill_model.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from nautilus_trader.backtest.models import FillModel
+from nautilus_trader.core.rust.model import BookType
+from nautilus_trader.core.rust.model import OrderSide
+from nautilus_trader.core.rust.model import OrderType
+from nautilus_trader.model.book import OrderBook
+from nautilus_trader.model.data import BookOrder
+from nautilus_trader.model.objects import Quantity
+
+
+_KALSHI_ORDER_TICK = Decimal("0.01")
+_UNLIMITED_BOOK_SIZE = 1_000_000
+
+
+def effective_prediction_market_slippage_tick(instrument) -> float:
+    """
+    Return the effective taker slippage tick for a prediction-market instrument.
+
+    Polymarket publishes a market-specific minimum tick size, so we can use the
+    instrument's `price_increment` directly.
+
+    Kalshi's API exposes 4-decimal fixed-point dollar prices, but the current
+    minimum tradable order tick is still one cent. For taker slippage modeling
+    we therefore use $0.01 on the 0-1 probability scale.
+    """
+    if str(instrument.id.venue) == "KALSHI":
+        return float(_KALSHI_ORDER_TICK)
+
+    return float(instrument.price_increment)
+
+
+class PredictionMarketTakerFillModel(FillModel):
+    """
+    Approximate taker slippage for prediction-market backtests.
+
+    The shared prediction-market backtests replay trades/bars without full
+    historical order-book depth, so they cannot model true price walking.
+    Instead, this fill model applies a deterministic one-tick adverse move for
+    non-limit orders:
+
+    - Polymarket: one market tick using the instrument's tick size
+    - Kalshi: one cent, matching the current minimum order tick
+
+    Limit orders keep the default exchange matching behavior.
+    """
+
+    def __init__(self) -> None:
+        # The slippage is modeled through a synthetic order book rather than
+        # FillModel.is_slipped(), so we disable the built-in L1 slip hook.
+        super().__init__(prob_fill_on_limit=1.0, prob_slippage=0.0)
+
+    def get_orderbook_for_fill_simulation(
+        self,
+        instrument,
+        order,
+        best_bid,
+        best_ask,
+    ):
+        if order.order_type == OrderType.LIMIT:
+            return None
+
+        tick = effective_prediction_market_slippage_tick(instrument)
+        slipped_bid = instrument.make_price(max(0.0, float(best_bid) - tick))
+        slipped_ask = instrument.make_price(min(1.0, float(best_ask) + tick))
+
+        book = OrderBook(
+            instrument_id=instrument.id,
+            book_type=BookType.L2_MBP,
+        )
+
+        # Build a symmetric synthetic book one adverse tick away from the touch.
+        # The matching engine will consume the relevant side depending on order side.
+        book.add(
+            BookOrder(
+                side=OrderSide.BUY,
+                price=slipped_bid,
+                size=Quantity(_UNLIMITED_BOOK_SIZE, instrument.size_precision),
+                order_id=1,
+            ),
+            0,
+            0,
+        )
+        book.add(
+            BookOrder(
+                side=OrderSide.SELL,
+                price=slipped_ask,
+                size=Quantity(_UNLIMITED_BOOK_SIZE, instrument.size_precision),
+                order_id=2,
+            ),
+            0,
+            0,
+        )
+
+        return book

--- a/nautilus_trader/adapters/prediction_market/research.py
+++ b/nautilus_trader/adapters/prediction_market/research.py
@@ -29,6 +29,7 @@ from nautilus_trader.adapters.prediction_market.backtest_utils import build_mark
 from nautilus_trader.adapters.prediction_market.backtest_utils import extract_price_points
 from nautilus_trader.adapters.prediction_market.backtest_utils import extract_realized_pnl
 from nautilus_trader.adapters.prediction_market.backtest_utils import infer_realized_outcome
+from nautilus_trader.adapters.prediction_market.fill_model import PredictionMarketTakerFillModel
 from nautilus_trader.analysis import legacy_plot_adapter as legacy_plot_adapter
 from nautilus_trader.analysis.legacy_plot_adapter import build_legacy_backtest_layout
 from nautilus_trader.analysis.legacy_plot_adapter import save_legacy_backtest_layout
@@ -308,6 +309,7 @@ def run_market_backtest(
     venue: Venue,
     base_currency: Currency,
     fee_model: Any,
+    fill_model: Any | None = None,
     initial_cash: float,
     probability_window: int,
     price_attr: str,
@@ -322,7 +324,16 @@ def run_market_backtest(
 ) -> dict[str, Any]:
     """
     Run one prediction-market backtest and emit a legacy chart.
+
+    Prediction-market market orders are taker-style orders against a central
+    limit order book. Historical backtests here replay trades/bars without full
+    book depth, so we apply a deterministic one-tick adverse fill model by
+    default to approximate slippage. Callers can override this with a custom
+    ``fill_model`` if needed.
     """
+    if fill_model is None:
+        fill_model = PredictionMarketTakerFillModel()
+
     engine = BacktestEngine(
         config=BacktestEngineConfig(
             trader_id=TraderId("BACKTESTER-001"),
@@ -336,6 +347,7 @@ def run_market_backtest(
         account_type=AccountType.CASH,
         base_currency=base_currency,
         starting_balances=[Money(initial_cash, base_currency)],
+        fill_model=fill_model,
         fee_model=fee_model,
     )
     engine.add_instrument(instrument)

--- a/tests/integration_tests/adapters/polymarket/test_loaders.py
+++ b/tests/integration_tests/adapters/polymarket/test_loaders.py
@@ -14,6 +14,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import pkgutil
+from decimal import Decimal
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -66,6 +67,11 @@ def trades_data():
     )
     assert data
     return msgspec.json.decode(data)
+
+
+@pytest.fixture
+def fee_rate_data():
+    return {"base_fee": 0}
 
 
 @pytest.fixture
@@ -158,6 +164,7 @@ async def test_find_market_by_slug_not_found(test_instrument):
 async def test_from_market_slug_uses_slug_endpoint(
     market_slug_data,
     market_details_data,
+    fee_rate_data,
 ):
     # Arrange
     mock_http_client = MagicMock(spec=nautilus_pyo3.HttpClient)
@@ -170,7 +177,11 @@ async def test_from_market_slug_uses_slug_endpoint(
     details_response.status = 200
     details_response.body = msgspec.json.encode(market_details_data)
 
-    mock_http_client.get = AsyncMock(side_effect=[slug_response, details_response])
+    fee_response = Mock()
+    fee_response.status = 200
+    fee_response.body = msgspec.json.encode(fee_rate_data)
+
+    mock_http_client.get = AsyncMock(side_effect=[slug_response, details_response, fee_response])
 
     # Act
     loader = await PolymarketDataLoader.from_market_slug(
@@ -188,6 +199,31 @@ async def test_from_market_slug_uses_slug_endpoint(
         "https://clob.polymarket.com/markets/"
         "0x270d5aa3b23be0d4e713361d603b187dd1919c71c74226ad867699f33972c5f2"
     )
+    assert mock_http_client.get.call_args_list[2].kwargs == {
+        "url": "https://clob.polymarket.com/fee-rate",
+        "params": {"token_id": market_details_data["tokens"][0]["token_id"]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_from_market_slug_uses_fee_rate_endpoint_when_available(
+    market_slug_data,
+    market_details_data,
+):
+    mock_http_client = MagicMock(spec=nautilus_pyo3.HttpClient)
+
+    slug_response = Mock(status=200, body=msgspec.json.encode(market_slug_data))
+    details_response = Mock(status=200, body=msgspec.json.encode(market_details_data))
+    fee_response = Mock(status=200, body=msgspec.json.encode({"base_fee": "200"}))
+    mock_http_client.get = AsyncMock(side_effect=[slug_response, details_response, fee_response])
+
+    loader = await PolymarketDataLoader.from_market_slug(
+        "kamala-harris-divorce-in-2025",
+        http_client=mock_http_client,
+    )
+
+    assert loader.instrument.maker_fee == Decimal("0.02")
+    assert loader.instrument.taker_fee == Decimal("0.02")
 
 
 @pytest.mark.asyncio
@@ -569,7 +605,7 @@ async def test_get_event_markets(test_instrument, event_data):
 
 
 @pytest.mark.asyncio
-async def test_from_event_slug(event_data, market_details_data):
+async def test_from_event_slug(event_data, market_details_data, fee_rate_data):
     # Arrange
     mock_http_client = MagicMock(spec=nautilus_pyo3.HttpClient)
 
@@ -581,9 +617,21 @@ async def test_from_event_slug(event_data, market_details_data):
     details_response.status = 200
     details_response.body = msgspec.json.encode(market_details_data)
 
-    # Event fetch + 3 market detail fetches (one per market in event)
+    fee_response = Mock()
+    fee_response.status = 200
+    fee_response.body = msgspec.json.encode(fee_rate_data)
+
+    # Event fetch + 3 market detail fetches + 3 fee-rate fetches (one per selected token)
     mock_http_client.get = AsyncMock(
-        side_effect=[event_response, details_response, details_response, details_response],
+        side_effect=[
+            event_response,
+            details_response,
+            fee_response,
+            details_response,
+            fee_response,
+            details_response,
+            fee_response,
+        ],
     )
 
     # Act
@@ -600,21 +648,25 @@ async def test_from_event_slug(event_data, market_details_data):
         assert loader.instrument is not None
 
     # Verify API calls
-    assert mock_http_client.get.call_count == 4  # 1 event + 3 market details
+    assert mock_http_client.get.call_count == 7  # 1 event + 3 market details + 3 fee-rate
     # First call should be to events API
     assert mock_http_client.get.call_args_list[0].kwargs["url"] == (
         "https://gamma-api.polymarket.com/events"
     )
     # Subsequent calls should be to CLOB market details API
-    for i in range(1, 4):
+    for i in (1, 3, 5):
         assert (
             "https://clob.polymarket.com/markets/"
             in (mock_http_client.get.call_args_list[i].kwargs["url"])
         )
+    for i in (2, 4, 6):
+        assert mock_http_client.get.call_args_list[i].kwargs["url"] == (
+            "https://clob.polymarket.com/fee-rate"
+        )
 
 
 @pytest.mark.asyncio
-async def test_from_event_slug_with_token_index(event_data, market_details_data):
+async def test_from_event_slug_with_token_index(event_data, market_details_data, fee_rate_data):
     # Arrange
     mock_http_client = MagicMock(spec=nautilus_pyo3.HttpClient)
 
@@ -626,8 +678,20 @@ async def test_from_event_slug_with_token_index(event_data, market_details_data)
     details_response.status = 200
     details_response.body = msgspec.json.encode(market_details_data)
 
+    fee_response = Mock()
+    fee_response.status = 200
+    fee_response.body = msgspec.json.encode(fee_rate_data)
+
     mock_http_client.get = AsyncMock(
-        side_effect=[event_response, details_response, details_response, details_response],
+        side_effect=[
+            event_response,
+            details_response,
+            fee_response,
+            details_response,
+            fee_response,
+            details_response,
+            fee_response,
+        ],
     )
 
     # Act - request second token (No outcome)

--- a/tests/unit_tests/adapters/prediction_market/test_fill_model.py
+++ b/tests/unit_tests/adapters/prediction_market/test_fill_model.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import decimal
+
+from nautilus_trader.adapters.prediction_market.fill_model import PredictionMarketTakerFillModel
+from nautilus_trader.adapters.prediction_market.fill_model import (
+    effective_prediction_market_slippage_tick,
+)
+from nautilus_trader.core.rust.model import OrderSide
+from nautilus_trader.model.enums import AssetClass
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import Symbol
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments import BinaryOption
+from nautilus_trader.model.objects import Currency
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.test_kit.stubs.execution import TestExecStubs
+
+
+def _make_instrument(
+    *,
+    venue: str,
+    symbol: str,
+    currency: str,
+    price_increment: str,
+    price_precision: int,
+) -> BinaryOption:
+    return BinaryOption(
+        instrument_id=InstrumentId(Symbol(symbol), Venue(venue)),
+        raw_symbol=Symbol(symbol),
+        asset_class=AssetClass.ALTERNATIVE,
+        currency=Currency.from_str(currency),
+        activation_ns=0,
+        expiration_ns=0,
+        price_precision=price_precision,
+        size_precision=2,
+        price_increment=Price.from_str(price_increment),
+        size_increment=Quantity.from_str("0.01"),
+        maker_fee=decimal.Decimal(0),
+        taker_fee=decimal.Decimal("0.01"),
+        outcome="Yes",
+        description=f"{venue} test market",
+        ts_event=0,
+        ts_init=0,
+    )
+
+
+def test_effective_prediction_market_slippage_tick_uses_polymarket_tick_size() -> None:
+    instrument = _make_instrument(
+        venue="POLYMARKET",
+        symbol="POLYTEST-YES",
+        currency="USDC",
+        price_increment="0.001",
+        price_precision=3,
+    )
+
+    assert effective_prediction_market_slippage_tick(instrument) == 0.001
+
+
+def test_effective_prediction_market_slippage_tick_uses_kalshi_order_tick() -> None:
+    instrument = _make_instrument(
+        venue="KALSHI",
+        symbol="KXTEST-YES",
+        currency="USD",
+        price_increment="0.0001",
+        price_precision=4,
+    )
+
+    assert effective_prediction_market_slippage_tick(instrument) == 0.01
+
+
+def test_prediction_market_fill_model_slips_polymarket_market_orders_by_one_market_tick() -> None:
+    instrument = _make_instrument(
+        venue="POLYMARKET",
+        symbol="POLYTEST-YES",
+        currency="USDC",
+        price_increment="0.001",
+        price_precision=3,
+    )
+    fill_model = PredictionMarketTakerFillModel()
+    order = TestExecStubs.market_order(instrument=instrument, order_side=OrderSide.BUY)
+
+    result = fill_model.get_orderbook_for_fill_simulation(
+        instrument,
+        order,
+        instrument.make_price(0.420),
+        instrument.make_price(0.430),
+    )
+
+    assert result is not None
+    bids = list(result.bids())
+    asks = list(result.asks())
+    assert bids[0].price == instrument.make_price(0.419)
+    assert asks[0].price == instrument.make_price(0.431)
+
+
+def test_prediction_market_fill_model_slips_kalshi_market_orders_by_one_cent() -> None:
+    instrument = _make_instrument(
+        venue="KALSHI",
+        symbol="KXTEST-YES",
+        currency="USD",
+        price_increment="0.0001",
+        price_precision=4,
+    )
+    fill_model = PredictionMarketTakerFillModel()
+    order = TestExecStubs.market_order(instrument=instrument, order_side=OrderSide.BUY)
+
+    result = fill_model.get_orderbook_for_fill_simulation(
+        instrument,
+        order,
+        instrument.make_price(0.4200),
+        instrument.make_price(0.4300),
+    )
+
+    assert result is not None
+    bids = list(result.bids())
+    asks = list(result.asks())
+    assert bids[0].price == instrument.make_price(0.4100)
+    assert asks[0].price == instrument.make_price(0.4400)
+
+
+def test_prediction_market_fill_model_leaves_limit_orders_to_default_matching() -> None:
+    instrument = _make_instrument(
+        venue="POLYMARKET",
+        symbol="POLYTEST-YES",
+        currency="USDC",
+        price_increment="0.001",
+        price_precision=3,
+    )
+    fill_model = PredictionMarketTakerFillModel()
+    order = TestExecStubs.limit_order(
+        instrument=instrument,
+        order_side=OrderSide.BUY,
+        price=instrument.make_price(0.420),
+    )
+
+    result = fill_model.get_orderbook_for_fill_simulation(
+        instrument,
+        order,
+        instrument.make_price(0.420),
+        instrument.make_price(0.430),
+    )
+
+    assert result is None

--- a/tests/unit_tests/adapters/prediction_market/test_research.py
+++ b/tests/unit_tests/adapters/prediction_market/test_research.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pandas as pd
 import pytest
 
+from nautilus_trader.adapters.prediction_market import research
+from nautilus_trader.adapters.prediction_market.fill_model import PredictionMarketTakerFillModel
 from nautilus_trader.adapters.prediction_market.research import save_aggregate_backtest_report
+from nautilus_trader.model.currencies import USDC_POS
+from nautilus_trader.model.identifiers import Venue
 
 
 def test_save_aggregate_backtest_report_writes_legacy_bokeh_html(tmp_path) -> None:
@@ -159,3 +166,82 @@ def test_save_aggregate_backtest_report_writes_legacy_bokeh_html(tmp_path) -> No
     assert "Fills (" in html
     assert "Monthly Returns" in html
     assert "plotly" not in html.lower()
+
+
+def test_run_market_backtest_uses_prediction_market_fill_model_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class DummyTrader:
+        def generate_order_fills_report(self) -> list[object]:
+            return []
+
+        def generate_positions_report(self) -> list[object]:
+            return []
+
+    class DummyEngine:
+        def __init__(self, config) -> None:
+            self.config = config
+            self.trader = DummyTrader()
+
+        def add_venue(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+        def add_instrument(self, instrument) -> None:
+            captured["instrument"] = instrument
+
+        def add_data(self, data) -> None:
+            captured["data"] = data
+
+        def add_strategy(self, strategy) -> None:
+            captured["strategy"] = strategy
+
+        def run(self) -> None:
+            captured["ran"] = True
+
+        def reset(self) -> None:
+            captured["reset"] = True
+
+        def dispose(self) -> None:
+            captured["disposed"] = True
+
+    monkeypatch.setattr(research, "BacktestEngine", DummyEngine)
+    monkeypatch.setattr(research, "extract_realized_pnl", lambda positions: 0.0)
+    monkeypatch.setattr(research, "extract_price_points", lambda data, price_attr: [])
+    monkeypatch.setattr(
+        research,
+        "build_brier_inputs",
+        lambda points, window, realized_outcome: (
+            pd.Series(dtype=float),
+            pd.Series(dtype=float),
+            pd.Series(dtype=float),
+        ),
+    )
+    monkeypatch.setattr(research, "build_market_prices", lambda price_points, resample_rule: [])
+    monkeypatch.setattr(research, "infer_realized_outcome", lambda instrument: None)
+
+    result = research.run_market_backtest(
+        market_id="demo-market",
+        instrument=SimpleNamespace(id="demo-instrument"),
+        data=[],
+        strategy=object(),
+        strategy_name="demo-strategy",
+        output_prefix="demo",
+        platform="polymarket",
+        venue=Venue("POLYMARKET"),
+        base_currency=USDC_POS,
+        fee_model=object(),
+        initial_cash=100.0,
+        probability_window=30,
+        price_attr="price",
+        count_key="trades",
+        emit_html=False,
+    )
+
+    fill_model = captured["fill_model"]
+    assert isinstance(fill_model, PredictionMarketTakerFillModel)
+    assert result["pnl"] == 0.0
+    assert captured["ran"] is True
+    assert captured["reset"] is True
+    assert captured["disposed"] is True


### PR DESCRIPTION
## Summary
- add a deterministic one-tick taker slippage model for prediction-market backtests
- use the Polymarket CLOB fee-rate endpoint to enrich loader instruments when market payload fees are zero
- cover the new slippage and Polymarket fee lookup behavior with tests

## Testing
- uv run pytest tests/integration_tests/adapters/polymarket/test_loaders.py tests/unit_tests/adapters/prediction_market/test_fill_model.py tests/unit_tests/adapters/prediction_market/test_research.py tests/unit_tests/examples/strategies/test_kalshi_spread_capture.py tests/unit_tests/examples/strategies/test_polymarket_spread_capture.py